### PR TITLE
DEVELOP define and printing to IS-Viewer64 output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,15 @@ ifeq ($(GRUCODE),f3d_20E)
   DEFINES += FAST3D_20E=1
 endif
 
+# DEVELOP - fake IS-Viewer presence and print normally disabled messages
+#   1 - includes code & runs it
+#   0 - does not
+DEVELOP ?= 1
+$(eval $(call validate-option,DEVELOP,0 1))
+ifeq ($(DEVELOP),1)
+  DEFINES += DEVELOP=1
+endif
+
 # USE_QEMU_IRIX - when ido is selected, select which way to emulate IRIX programs
 #   1 - use qemu-irix
 #   0 - statically recompile the IRIX programs

--- a/include/headers.h
+++ b/include/headers.h
@@ -29,7 +29,7 @@
  * build switches
  */
 #define	DEBUGSW		0
-#define	DEVELOP		0
+// #define	DEVELOP		0
 #define	VERSION_E3	0
 
 /*

--- a/include/sm64.h
+++ b/include/sm64.h
@@ -399,7 +399,4 @@
 
 #define C_BUTTONS     (U_CBUTTONS | D_CBUTTONS | L_CBUTTONS | R_CBUTTONS   )
 
-// stubbed out printf, set to osSyncPrintf if build type was DEVELOP. needs a full version of libultra for a reimplementation.
-#define rmonpf
-
 #endif // SM64_H

--- a/include/ultra64.h
+++ b/include/ultra64.h
@@ -32,4 +32,12 @@
 #include <PR/libaudio.h>
 #include <PR/libultra.h>
 
+// stubbed out printf, set to osSyncPrintf if build type was DEVELOP
+extern void osSyncPrintf(const char* fmt, ...);
+#ifdef DEVELOP
+#define rmonpf osSyncPrintf
+#else
+#define rmonpf
+#endif
+
 #endif

--- a/lib/src/osSyncPrintf.c
+++ b/lib/src/osSyncPrintf.c
@@ -1,0 +1,130 @@
+#include "macros.h"
+#include "libultra_internal.h"
+#include "PR/rcp.h"
+#include "piint.h"
+#include "stdlib.h"
+#include "stdarg.h"
+
+typedef struct {
+    /* 0x00 */ u32 magic; // IS64
+    /* 0x04 */ u32 get;
+    /* 0x08 */ u8 unk_08[0x14 - 0x08];
+    /* 0x14 */ u32 put;
+    /* 0x18 */ u8 unk_18[0x20 - 0x18];
+    /* 0x20 */ u8 data[0x10000 - 0x20];
+} ISVDbg;
+
+#define	IO_WRITE(addr,data)	(*(vu32 *)PHYS_TO_K1(addr)=(u32)(data))
+
+#define IS64_MAGIC  0x49533634  // 'IS64'
+
+typedef char *outfun(char*,const char*,size_t);
+extern int _Printf(outfun prout, char *arg, const char *fmt, va_list args);
+
+#ifdef DEVELOP
+static ISVDbg* gISVDbgPrnAdrs;
+
+static void* __printfunc = NULL;
+
+// implement functions from libultra that weren't added into the vanilla game (forgot the source, might be depot.tar or libultra_modern)
+s32 osPiRawWriteIo(u32 devAddr, u32 data) {
+    register u32 stat;
+    WAIT_ON_IO_BUSY(stat);
+    IO_WRITE(osRomBase | devAddr, data);
+    return(0);
+}
+
+s32 osPiReadIo(u32 devAddr, u32 *data) {
+    register s32 ret;
+    __osPiGetAccess();
+    ret = osPiRawReadIo(devAddr, data);
+    __osPiRelAccess();
+    return(ret);
+}
+
+s32 osPiWriteIo(u32 devAddr, u32 data) {
+    register s32 ret;
+    __osPiGetAccess();
+    ret = osPiRawWriteIo(devAddr, data);
+    __osPiRelAccess();
+    return(ret);
+}
+
+// isPrintfInit, is_proutSyncPrintf, and osSyncPrintf are from https://github.com/ModernN64SDKArchives/libultra_modern
+// the following functions originally used the Expanded Peripheral Interface variants (osEPiReadIo, osEPiWriteIo) but
+// those only existed in later OS versions so they have been modified to use the regular Peripheral Interface functions
+static void isPrintfInit(void) {
+    osPiWriteIo((u32)&gISVDbgPrnAdrs->put, 0);
+    osPiWriteIo((u32)&gISVDbgPrnAdrs->get, 0);
+    osPiWriteIo((u32)gISVDbgPrnAdrs, IS64_MAGIC);
+}
+
+static void* is_proutSyncPrintf(UNUSED void* arg, const u8* str, u32 count) {
+    u32 data;
+    s32 p;
+    s32 start;
+    s32 end;
+
+    if (gISVDbgPrnAdrs == NULL) {
+        return (void*)0;
+    }
+
+    osPiReadIo((u32)&gISVDbgPrnAdrs->magic, &data);
+    if (data != IS64_MAGIC) {
+        return (void*)1;
+    }
+    osPiReadIo((u32)&gISVDbgPrnAdrs->get, &data);
+    p = data;
+    osPiReadIo((u32)&gISVDbgPrnAdrs->put, &data);
+
+    start = data;
+    end = start + count;
+
+    if (end >= 0xffe0) {
+        end -= 0xffe0;
+        if (p < end || start < p) {
+            return (void*)1;
+        }
+    } else {
+        if (start < p && p < end) {
+            return (void*)1;
+        }
+    }
+    while (count) {
+        if (*str != '\0') {
+            s32 shift = start & 3;
+            u32 addr = (u32)&gISVDbgPrnAdrs->data[start & 0xFFFFFFC];
+
+            shift = (3 - shift) * 8;
+
+            osPiReadIo(addr, &data);
+            osPiWriteIo(addr, (data & ~(0xff << shift)) | (*str << shift));
+
+            start++;
+            if (start >= 0xffe0) {
+                start -= 0xffe0;
+            }
+        }
+        count--;
+        str++;
+    }
+    osPiWriteIo((u32)&gISVDbgPrnAdrs->put, start);
+
+    return (void*)1;
+}
+
+void osSyncPrintf(const char* fmt, ...) {
+    va_list ap;
+
+    va_start(ap, fmt);
+    if (__printfunc == NULL) { // osSyncPrintf has been modified here to automatically initialize IS-Viewer64 values
+        gISVDbgPrnAdrs = (ISVDbg*)0x13FF0000; // cen64 has this hardcoded according to https://github.com/HackerN64/HackerSM64
+        __printfunc = is_proutSyncPrintf;
+        isPrintfInit();
+    }
+    if (__printfunc != NULL) {
+        _Printf(__printfunc, NULL, fmt, ap);
+    }
+    va_end(ap);
+}
+#endif

--- a/sm64.ld
+++ b/sm64.ld
@@ -267,6 +267,7 @@ SECTIONS
         BUILD_DIR/libultra.a:__osGetCause.o(.text);
         BUILD_DIR/libultra.a:__osAtomicDec.o(.text);
         BUILD_DIR/libultra.a:guLookAtRef.o(.text); /* Fast3DEX2 only */
+        BUILD_DIR/libultra.a:osSyncPrintf.o(.text);
         BUILD_DIR/lib/rsp.o(.text);
 
         /* data */

--- a/src/game/main.c
+++ b/src/game/main.c
@@ -102,25 +102,26 @@ void unknown_main_func(void) {
 }
 
 #define STACK_CHECK_CODE 0x8877665544332211LL
+#define GET_AS_U64(v) ((u64*)&v)
 
 void InitStackMemory(void) {
 #ifdef DEVELOP
-    gIdleThreadStack[256] = STACK_CHECK_CODE;
-    gThread3Stack[256] = STACK_CHECK_CODE;
-    gThread4Stack[256] = STACK_CHECK_CODE;
-    gThread5Stack[256] = STACK_CHECK_CODE;
+    GET_AS_U64(gIdleThreadStack)[256] = STACK_CHECK_CODE;
+    GET_AS_U64(gThread3Stack)[256] = STACK_CHECK_CODE;
+    GET_AS_U64(gThread4Stack)[256] = STACK_CHECK_CODE;
+    GET_AS_U64(gThread5Stack)[256] = STACK_CHECK_CODE;
 #endif
 }
 
 void CheckStackMemory(void) {
 #ifdef DEVELOP
-    if (gIdleThreadStack[256] != STACK_CHECK_CODE)
+    if (GET_AS_U64(gIdleThreadStack)[256] != STACK_CHECK_CODE)
         rmonpf(("idle thread stack over\n"));
-    if (gThread3Stack[256] != STACK_CHECK_CODE)
+    if (GET_AS_U64(gThread3Stack)[256] != STACK_CHECK_CODE)
         rmonpf(("main thread stack over\n"));
-    if (gThread4Stack[256] != STACK_CHECK_CODE)
+    if (GET_AS_U64(gThread4Stack)[256] != STACK_CHECK_CODE)
         rmonpf(("audio thread stack over\n"));
-    if (gThread5Stack[256] != STACK_CHECK_CODE)
+    if (GET_AS_U64(gThread5Stack)[256] != STACK_CHECK_CODE)
         rmonpf(("graph thread stack over\n"));
 #endif
 }
@@ -403,7 +404,7 @@ void thread1_idle(UNUSED void *arg) {
     }
 }
 
-#if DEVELOP
+#ifdef RAMROM_ARGUMENTS
 /********************************************************************************/
 /*	Read argument.
  */
@@ -440,7 +441,7 @@ static void CheckDebugOption(ArgRecord *argrec) {
 #endif
 
 void main_func(void) {
-#if DEVELOP
+#ifdef RAMROM_ARGUMENTS
     ArgRecord argrec;
 #else
     UNUSED u8 filler[64];
@@ -448,7 +449,7 @@ void main_func(void) {
 
     osInitialize();
     InitStackMemory();
-#if DEVELOP
+#ifdef RAMROM_ARGUMENTS
     ReadArgument(&argrec);
     CheckDebugOption(&argrec);
 #endif

--- a/src/goddard/gd_main.h
+++ b/src/goddard/gd_main.h
@@ -10,6 +10,9 @@
 // "#define printf(...) /* nothing */" wasn't an option.)
 // This macro is separate from the gd_printf function; one probably
 // forwarded to the other, but it is hard to tell in which direction.
+#ifdef DEVELOP
+#define printf rmonpf
+#else
 #ifdef __GNUC__
 #define printf(...)                                       \
     _Pragma ("GCC diagnostic push")                       \
@@ -18,6 +21,7 @@
     _Pragma ("GCC diagnostic pop")
 #else
 #define printf
+#endif
 #endif
 
 // structs

--- a/src/goddard/renderer.c
+++ b/src/goddard/renderer.c
@@ -803,6 +803,9 @@ f64 gd_sqrt_d(f64 x) {
     return sqrtf(x);
 }
 
+#ifdef DEVELOP
+#define gd_printf rmonpf
+#else
 /**
  * Unused
  */
@@ -908,6 +911,7 @@ void gd_printf(const char *format, ...) {
         fatal_printf("printf too long");
     }
 }
+#endif
 
 /* 24A19C -> 24A1D4 */
 void gd_exit(UNUSED s32 code) {

--- a/src/goddard/renderer.h
+++ b/src/goddard/renderer.h
@@ -43,7 +43,11 @@ f32 get_time_scale(void);
 f64 gd_sin_d(f64 x);
 f64 gd_cos_d(f64 x);
 f64 gd_sqrt_d(f64 x);
+#ifdef DEVELOP
+#define gd_printf rmonpf
+#else
 void gd_printf(const char *format, ...);
+#endif
 void gd_exit(UNUSED s32 code) NORETURN;
 void gd_free(void *ptr);
 void *gd_allocblock(u32 size);


### PR DESCRIPTION
This pull request reroutes rmonpf calls that I left in a previous commit to osSyncPrintf once the DEVELOP define is enabled (it is by default).

In OS 2.0L, that function may be initialized by various ways. In this implementation, it is using the IS-Viewer64. 

The IS-Viewer64 did NOT exist in 1995 and is only used here as it is emulatable, the Nintendo 64 development board (google: gload) is not. This makes this function inaccurate.

According to the [N64 OS documentation](https://ultra64.ca/files/documentation/online-manuals/functions_reference_manual_2.0i/tools/osSyncPrintf.html), before OS 2.0F, the function called had a bit of an impact on console performance. This is not simulated as the function included was pieced with code from OS 2.0L. Maybe I will take a look at the OS 2.0E libultra copy, or even at the OS 1.0G copy.

A patch is also available [here](https://github.com/Phil564/showfloor/releases/download/continuous/showfloor-logging.bps).