### PR TITLE
prioritise mips64-elf- toolchain to resolve ABI conflicts on arch linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -266,10 +266,10 @@ IQUE_LD_PATH := $(TOOLS_DIR)/ique_ld
 # detect prefix for MIPS toolchain
 ifneq      ($(call find-command,mips-linux-gnu-ld),)
   CROSS := mips-linux-gnu-
-else ifneq ($(call find-command,mips64-linux-gnu-ld),)
-  CROSS := mips64-linux-gnu-
 else ifneq ($(call find-command,mips64-elf-ld),)
   CROSS := mips64-elf-
+else ifneq ($(call find-command,mips64-linux-gnu-ld),)
+  CROSS := mips64-linux-gnu-
 else
   $(error Unable to detect a suitable MIPS toolchain installed)
 endif


### PR DESCRIPTION
On Arch Linux systems where both mips64-elf- and mips64-linux-gnu- are installed, the default detection order would select mips64-linux-gnu-, which leads to linker failures due to ABI incompatibility (ABI is incompatible with that of the selected emulation), as the Linux-targeted toolchain uses a different default ABI.

Works with Debian/Ubuntu, thought it might not work on other distributions like Fedora.