### PR TITLE
Use `ubuntu:22.04` in `Dockerfile`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04 as build
+FROM ubuntu:22.04 as build
 
 RUN apt-get update && \
     apt-get install -y \


### PR DESCRIPTION
This should fix GitHub runner issues since 18.04 has reached end-of-life.